### PR TITLE
Enable usage of CRC peripheral

### DIFF
--- a/api/checksumes.h
+++ b/api/checksumes.h
@@ -30,10 +30,10 @@ uint16_t computeCrc(const void* buf, size_t len, uint16_t initialValue);
   * CCSDS recommends 0 (but Warning: some times 0xffff) as initial value 
   */
 
-class CRC {
+class Crc {
     uint16_t lookUpTable[256];
 public:
-    CRC(); 
+    Crc(); 
     uint16_t computeCRC(const void* buf, size_t len, uint16_t initialValue);
 };
 

--- a/src/bare-metal/stm32f4/stm32f4xx_conf.h
+++ b/src/bare-metal/stm32f4/stm32f4xx_conf.h
@@ -27,7 +27,7 @@
 /* Uncomment the line below to enable peripheral header file inclusion */
 //#include "stm32f4xx_adc.h"
 //#include "stm32f4xx_can.h"
-//#include "stm32f4xx_crc.h"
+#include "stm32f4xx_crc.h"
 //#include "stm32f4xx_cryp.h"
 //#include "stm32f4xx_dac.h"
 //#include "stm32f4xx_dbgmcu.h"

--- a/src/independent/checksumes.cpp
+++ b/src/independent/checksumes.cpp
@@ -70,7 +70,7 @@ uint16_t computeCrc(const void* buf, size_t len, uint16_t initialValue) {
   * first it generates a luck up table to speed up the crc computation
   */
 
-CRC::CRC() {
+Crc::Crc() {
     for (int i=0; i < 256; i++) {
         uint16_t tmp=0;
         if ((i & 1) != 0)   tmp=tmp ^ 0x1021;
@@ -85,7 +85,7 @@ CRC::CRC() {
     }
 }
 
-uint16_t CRC::computeCRC(const void* buf, size_t len, uint16_t initialValue) {
+uint16_t Crc::computeCRC(const void* buf, size_t len, uint16_t initialValue) {
     uint16_t currentValue = initialValue;
     const uint8_t* data = static_cast<const uint8_t*>(buf);
 

--- a/support/support-programs/middleware-standalone/api/checksumes.h
+++ b/support/support-programs/middleware-standalone/api/checksumes.h
@@ -29,10 +29,10 @@ uint16_t computeCrc(const void* buf, size_t len, uint16_t initialValue);
   * CCSDS recommends 0 (but Warning: some times 0xffff) as initial value 
   */
 
-class Crc {
+class CRC {
     uint16_t lookUpTable[256];
 public:
-    Crc(); 
+    CRC(); 
     uint16_t computeCRC(const void* buf, size_t len, uint16_t initialValue);
 };
 

--- a/support/support-programs/middleware-standalone/api/checksumes.h
+++ b/support/support-programs/middleware-standalone/api/checksumes.h
@@ -29,10 +29,10 @@ uint16_t computeCrc(const void* buf, size_t len, uint16_t initialValue);
   * CCSDS recommends 0 (but Warning: some times 0xffff) as initial value 
   */
 
-class CRC {
+class Crc {
     uint16_t lookUpTable[256];
 public:
-    CRC(); 
+    Crc(); 
     uint16_t computeCRC(const void* buf, size_t len, uint16_t initialValue);
 };
 


### PR DESCRIPTION
This PR fixes a conflict with a class called `CRC` and an STM32F411 library macro with the same name. Moreover, the CRC header is now included in `stm32f4xx_conf.h`, thus enabling usage of the CRC peripheral.