### PR TITLE
Remove target `rodos_without_main`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,42 +25,23 @@ endif ()
 file(GLOB_RECURSE independent_sources
     src/independent/*.cpp
     support/support-libs/*.cpp)
-set(main_cpp "${CMAKE_CURRENT_SOURCE_DIR}/src/independent/main.cpp")
-set(independent_sources_without_main ${independent_sources})
-list(REMOVE_ITEM independent_sources_without_main ${main_cpp})
 
 add_library(rodos_rodos STATIC ${independent_sources})
 add_library(rodos::rodos ALIAS rodos_rodos)
 add_library(rodos ALIAS rodos_rodos)
-add_library(rodos_without_main STATIC ${independent_sources_without_main})
-add_library(rodos::without_main ALIAS rodos_without_main)
 set_target_properties(rodos_rodos PROPERTIES
 EXPORT_NAME rodos
 OUTPUT_NAME rodos
 )
-set_target_properties(rodos_without_main PROPERTIES
-    EXPORT_NAME without_main
-)
-
-# FIXME: That does not work. rodos_rodos needs to be the way it was before
-# target_link_libraries(rodos_rodos PUBLIC rodos_without_main)
 
 file(GLOB port_sources
     src/${port_dir}/*.cpp
     src/${port_dir}/*.c
     src/${port_dir}/hal/*.cpp
     src/${port_dir}/*.S)
-    target_sources(rodos_rodos PRIVATE ${port_sources})
-target_sources(rodos_without_main PRIVATE ${port_sources})
+target_sources(rodos_rodos PRIVATE ${port_sources})
 
 target_include_directories(rodos_rodos PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/api>
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/api/hal>
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/${port_dir}>
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/${port_dir}/include>
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/support/support-libs>
-)
-target_include_directories(rodos_without_main PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/api>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/api/hal>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/${port_dir}>
@@ -73,16 +54,10 @@ target_compile_options(rodos_rodos PUBLIC -fno-exceptions)
 target_compile_options(rodos_rodos PRIVATE -Wall -Wpedantic -Wextra -Wcast-qual -Wconversion
 -Wsign-conversion -Wfloat-conversion -Wdouble-promotion -Wnull-dereference -Wstrict-aliasing -Wno-long-long
 -Wno-cpp)
-target_compile_features(rodos_without_main PUBLIC cxx_std_14)
-target_compile_options(rodos_without_main PUBLIC -fno-exceptions)
-target_compile_options(rodos_without_main PRIVATE -Wall -Wpedantic -Wextra -Wcast-qual -Wconversion
-    -Wsign-conversion -Wfloat-conversion -Wdouble-promotion -Wnull-dereference -Wstrict-aliasing -Wno-long-long
-    -Wno-cpp)
 
 option(ENABLE_RODOS_RTTI "Build RODOS with run-time type information" OFF)
 if (NOT ENABLE_RODOS_RTTI)
     target_compile_options(rodos_rodos PUBLIC $<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>)
-    target_compile_options(rodos_without_main PUBLIC $<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>)
 endif ()
 
 
@@ -93,10 +68,6 @@ if (is_port_baremetal)
     target_include_directories(rodos_rodos PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/bare-metal-generic>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/bare-metal-generic/ip/lwip/include>)
-    target_sources(rodos_without_main PRIVATE ${baremetal_generic_sources})
-    target_include_directories(rodos_without_main PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/bare-metal-generic>
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/bare-metal-generic/ip/lwip/include>)
 endif ()
 
 
@@ -106,19 +77,16 @@ endif ()
 if (sources_to_add)
     file(GLOB files ${sources_to_add})
     target_sources(rodos_rodos PRIVATE ${files})
-    target_sources(rodos_without_main PRIVATE ${files})
 endif ()
 
 if (directories_to_include)
     foreach(dir ${directories_to_include})
         target_include_directories(rodos_rodos PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/${dir}>)
-        target_include_directories(rodos_without_main PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/${dir}>)
     endforeach()
 endif ()
 
 if (libraries_to_link)
     target_link_libraries(rodos_rodos PUBLIC ${libraries_to_link})
-    target_link_libraries(rodos_without_main PUBLIC ${libraries_to_link})
 endif ()
 
 if (EXECUTABLE)

--- a/cmake/install-rules.cmake
+++ b/cmake/install-rules.cmake
@@ -57,7 +57,6 @@ endif ()
 # ... INCLUDES DESTINATION ...) way.
 foreach(dir ${directories_to_include})
     target_include_directories(rodos_rodos PUBLIC $<INSTALL_INTERFACE:${rodos_INSTALL_INCLUDEDIR}/${dir}>)
-    target_include_directories(rodos_without_main PUBLIC $<INSTALL_INTERFACE:${rodos_INSTALL_INCLUDEDIR}/${dir}>)
 endforeach()
 
 set(rodos_INSTALL_LIBDIR ${CMAKE_INSTALL_LIBDIR}/${package})
@@ -65,7 +64,7 @@ set(rodos_INSTALL_LIBDIR ${CMAKE_INSTALL_LIBDIR}/${package})
 # Define how to install which targets and create an export. If possible define the include
 # directories for the exported targets here.
 install(
-    TARGETS rodos_rodos rodos_without_main EXPORT rodosTargets
+    TARGETS rodos_rodos EXPORT rodosTargets
     ARCHIVE
         DESTINATION ${rodos_INSTALL_LIBDIR}
     INCLUDES

--- a/src/independent/main.cpp
+++ b/src/independent/main.cpp
@@ -27,12 +27,8 @@
 
 namespace RODOS {
 
-// I don't know why this definition was moved to main, I don't understand the comment, but I need to
-// move it back to topic.c where it belongs, because otherwise we get get linker errors from the
-// rodos_without_main library if we build for coverage with -fkeep-inline-functions in the COBC SW
-// repo.
 /** This shall be in topicInterface, but to do not link if we do not need...*/
-// List TopicInterface::topicList = 0;
+List TopicInterface::topicList = 0;
 
 /********************************/
 

--- a/src/independent/topic.cpp
+++ b/src/independent/topic.cpp
@@ -24,10 +24,6 @@ namespace RODOS {
 
 // List TopicInterface::topicList = 0; This shall be here, but moved to main
 
-// Patrick Kappl: I don't know why this definition was moved to main, but I need to move it back to
-// here for the rodos_without_main target
-List TopicInterface::topicList = 0;
-
 static Application applicationName("Topics & Middleware", APID_MIDDLEWARE);
 
 TopicInterface::TopicInterface(int64_t id, size_t len, const char* name, bool _onlyLocal) : ListElement(topicList, name)  {


### PR DESCRIPTION
We no longer need this for the COBC SW. We have the CatchRodos testing framework now.