### PR TITLE
No longer require hard-coding the vector table offset

### DIFF
--- a/src/bare-metal/stm32f4/system_stm32f4xx.c
+++ b/src/bare-metal/stm32f4/system_stm32f4xx.c
@@ -515,7 +515,10 @@ void SystemInit(void)
 #ifdef VECT_TAB_SRAM
   SCB->VTOR = SRAM_BASE | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal SRAM */
 #else
-  SCB->VTOR = FLASH_BASE | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal FLASH */
+  /* If we don't want to offset, the vector table we don't need to set the register */
+  #if VECT_TAB_OFFSET != 0
+    SCB->VTOR = FLASH_BASE | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal FLASH */
+  #endif
 #endif
 }
 

--- a/src/bare-metal/stm32f4/system_stm32f4xx.c
+++ b/src/bare-metal/stm32f4/system_stm32f4xx.c
@@ -6,20 +6,20 @@
   * @date    19-September-2013
   * @brief   CMSIS Cortex-M4 Device Peripheral Access Layer System Source File.
   *          This file contains the system clock configuration for STM32F4xx devices.
-  *             
-  * 1.  This file provides two functions and one global variable to be called from 
+  *
+  * 1.  This file provides two functions and one global variable to be called from
   *     user application:
   *      - SystemInit(): Setups the system clock (System clock source, PLL Multiplier
   *                      and Divider factors, AHB/APBx prescalers and Flash settings),
-  *                      depending on the configuration made in the clock xls tool. 
-  *                      This function is called at startup just after reset and 
+  *                      depending on the configuration made in the clock xls tool.
+  *                      This function is called at startup just after reset and
   *                      before branch to main program. This call is made inside
   *                      the "startup_stm32f4xx.s" file.
   *
   *      - SystemCoreClock variable: Contains the core clock (HCLK), it can be used
-  *                                  by the user application to setup the SysTick 
+  *                                  by the user application to setup the SysTick
   *                                  timer or configure other parameters.
-  *                                     
+  *
   *      - SystemCoreClockUpdate(): Updates the variable SystemCoreClock and must
   *                                 be called whenever the core clock is changed
   *                                 during program execution.
@@ -29,7 +29,7 @@
   *    configure the system clock before to branch to main program.
   *
   * 3. If the system clock source selected by user fails to startup, the SystemInit()
-  *    function will do nothing and HSI still used as system clock source. User can 
+  *    function will do nothing and HSI still used as system clock source. User can
   *    add some code to deal with this issue inside the SetSysClock() function.
   *
   * 4. The default value of HSE crystal is set to 8MHz, refer to "HSE_VALUE" define
@@ -226,8 +226,8 @@
   *        Require 48MHz for USB OTG FS,          | Disabled
   *        SDIO and RNG clock                     |
   *-----------------------------------------------------------------------------
-  *=============================================================================      
-  ****************************************************************************** 
+  *=============================================================================
+  ******************************************************************************
   * @attention
   *
   * <h2><center>&copy; COPYRIGHT 2013 STMicroelectronics</center></h2>
@@ -238,8 +238,8 @@
   *
   *        http://www.st.com/software_license_agreement_liberty_v2
   *
-  * Unless required by applicable law or agreed to in writing, software 
-  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
   * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   * See the License for the specific language governing permissions and
   * limitations under the License.
@@ -253,8 +253,8 @@
 
 /** @addtogroup stm32f4xx_system
   * @{
-  */  
-  
+  */
+
 /** @addtogroup STM32F4xx_System_Private_Includes
   * @{
   */
@@ -281,7 +281,7 @@
 /************************* Miscellaneous Configuration ************************/
 /*!< Uncomment the following line if you need to use external SRAM or SDRAM mounted
      on STM324xG_EVAL/STM324x7I_EVAL/STM324x9I_EVAL boards as data memory  */
-     
+
 #if defined (STM32F40_41xxx) || defined (STM32F427_437xx) || defined (STM32F429_439xx)
 /* #define DATA_IN_ExtSRAM */
 #endif /* STM32F40_41xxx || STM32F427_437x || STM32F429_439xx */
@@ -295,7 +295,7 @@
 /* #define VECT_TAB_SRAM */
 
 #if BOOTIMAGE_PAGE==1
-#define VECT_TAB_OFFSET  0x00004200 
+#define VECT_TAB_OFFSET  0x00004200
 #elif BOOTIMAGE_PAGE==2
 #define VECT_TAB_OFFSET  0x00008200
 #elif BOOTIMAGE_PAGE==3
@@ -317,7 +317,7 @@
 #elif BOOTIMAGE_PAGE==11
 #define VECT_TAB_OFFSET  0x000E0200
 #else
-#define VECT_TAB_OFFSET  0x00000000 /*!< Vector Table base offset field. 
+#define VECT_TAB_OFFSET  0x00000000 /*!< Vector Table base offset field.
                                   This value must be a multiple of 0x200. */
 #endif
 /******************************************************************************/
@@ -457,7 +457,7 @@ __I uint8_t AHBPrescTable[16] = {0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 6, 7, 8, 9}
 static void SetSysClock(void);
 
 #if defined (DATA_IN_ExtSRAM) || defined (DATA_IN_ExtSDRAM)
-static void SystemInit_ExtMemCtl(void); 
+static void SystemInit_ExtMemCtl(void);
 #endif /* DATA_IN_ExtSRAM || DATA_IN_ExtSDRAM */
 
 /**
@@ -470,7 +470,7 @@ static void SystemInit_ExtMemCtl(void);
 
 /**
   * @brief  Setup the microcontroller system
-  *         Initialize the Embedded Flash Interface, the PLL and update the 
+  *         Initialize the Embedded Flash Interface, the PLL and update the
   *         SystemFrequency variable.
   * @param  None
   * @retval None
@@ -504,10 +504,10 @@ void SystemInit(void)
   RCC->CIR = 0x00000000;
 
 #if defined (DATA_IN_ExtSRAM) || defined (DATA_IN_ExtSDRAM)
-  SystemInit_ExtMemCtl(); 
+  SystemInit_ExtMemCtl();
 #endif /* DATA_IN_ExtSRAM || DATA_IN_ExtSDRAM */
-         
-  /* Configure the System clock source, PLL Multiplier and Divider factors, 
+
+  /* Configure the System clock source, PLL Multiplier and Divider factors,
      AHB/APBx prescalers and Flash settings ----------------------------------*/
   SetSysClock();
 
@@ -524,41 +524,41 @@ void SystemInit(void)
   *         The SystemCoreClock variable contains the core clock (HCLK), it can
   *         be used by the user application to setup the SysTick timer or configure
   *         other parameters.
-  *           
+  *
   * @note   Each time the core clock (HCLK) changes, this function must be called
   *         to update SystemCoreClock variable value. Otherwise, any configuration
-  *         based on this variable will be incorrect.         
-  *     
-  * @note   - The system frequency computed by this function is not the real 
-  *           frequency in the chip. It is calculated based on the predefined 
+  *         based on this variable will be incorrect.
+  *
+  * @note   - The system frequency computed by this function is not the real
+  *           frequency in the chip. It is calculated based on the predefined
   *           constant and the selected clock source:
-  *             
+  *
   *           - If SYSCLK source is HSI, SystemCoreClock will contain the HSI_VALUE(*)
-  *                                              
+  *
   *           - If SYSCLK source is HSE, SystemCoreClock will contain the HSE_VALUE(**)
-  *                          
-  *           - If SYSCLK source is PLL, SystemCoreClock will contain the HSE_VALUE(**) 
+  *
+  *           - If SYSCLK source is PLL, SystemCoreClock will contain the HSE_VALUE(**)
   *             or HSI_VALUE(*) multiplied/divided by the PLL factors.
-  *         
+  *
   *         (*) HSI_VALUE is a constant defined in stm32f4xx.h file (default value
   *             16 MHz) but the real value may vary depending on the variations
-  *             in voltage and temperature.   
-  *    
+  *             in voltage and temperature.
+  *
   *         (**) HSE_VALUE is a constant defined in stm32f4xx.h file (default value
   *              25 MHz), user has to ensure that HSE_VALUE is same as the real
   *              frequency of the crystal used. Otherwise, this function may
   *              have wrong result.
-  *                
+  *
   *         - The result of this function could be not correct when using fractional
   *           value for HSE crystal.
-  *     
+  *
   * @param  None
   * @retval None
   */
 void SystemCoreClockUpdate(void)
 {
   uint32_t tmp = 0, pllvco = 0, pllp = 2, pllsource = 0, pllm = 2;
-  
+
   /* Get SYSCLK source -------------------------------------------------------*/
   tmp = RCC->CFGR & RCC_CFGR_SWS;
 
@@ -574,10 +574,10 @@ void SystemCoreClockUpdate(void)
 
       /* PLL_VCO = (HSE_VALUE or HSI_VALUE / PLL_M) * PLL_N
          SYSCLK = PLL_VCO / PLL_P
-         */    
+         */
       pllsource = (RCC->PLLCFGR & RCC_PLLCFGR_PLLSRC) >> 22;
       pllm = RCC->PLLCFGR & RCC_PLLCFGR_PLLM;
-      
+
       if (pllsource != 0)
       {
         /* HSE used as PLL clock source */
@@ -604,10 +604,10 @@ void SystemCoreClockUpdate(void)
 }
 
 /**
-  * @brief  Configures the System clock source, PLL Multiplier and Divider factors, 
+  * @brief  Configures the System clock source, PLL Multiplier and Divider factors,
   *         AHB/APBx prescalers and Flash settings
-  * @Note   This function should be called only once the RCC clock configuration  
-  *         is reset to the default reset state (done in SystemInit() function).   
+  * @Note   This function should be called only once the RCC clock configuration
+  *         is reset to the default reset state (done in SystemInit() function).
   * @param  None
   * @retval None
   */
@@ -617,10 +617,10 @@ static void SetSysClock(void)
 /*            PLL (clocked by HSE) used as System clock source                */
 /******************************************************************************/
   __IO uint32_t StartUpCounter = 0, HSEStatus = 0;
-  
+
   /* Enable HSE */
   RCC->CR |= ((uint32_t)RCC_CR_HSEON);
- 
+
   /* Wait till HSE is ready and if Time out is reached exit */
   do
   {
@@ -646,10 +646,10 @@ static void SetSysClock(void)
     /* HCLK = SYSCLK / 1*/
     RCC->CFGR |= RCC_CFGR_HPRE_DIV1;
 
-#if defined (STM32F40_41xxx) || defined (STM32F427_437xx) || defined (STM32F429_439xx)      
+#if defined (STM32F40_41xxx) || defined (STM32F427_437xx) || defined (STM32F429_439xx)
     /* PCLK2 = HCLK / 2*/
     RCC->CFGR |= RCC_CFGR_PPRE2_DIV2;
-    
+
     /* PCLK1 = HCLK / 4*/
     RCC->CFGR |= RCC_CFGR_PPRE1_DIV4;
 #endif /* STM32F40_41xxx || STM32F427_437x || STM32F429_439xx */
@@ -657,11 +657,11 @@ static void SetSysClock(void)
 #if defined (STM32F401xx) || defined (STM32F411xE)
     /* PCLK2 = HCLK / 2*/
     RCC->CFGR |= RCC_CFGR_PPRE2_DIV1;
-    
+
     /* PCLK1 = HCLK / 4*/
     RCC->CFGR |= RCC_CFGR_PPRE1_DIV2;
 #endif /* STM32F401xx */
-   
+
     /* Configure the main PLL */
     RCC->PLLCFGR = (uint32_t)((uint32_t)0x20000000 | PLL_M | (PLL_N << 6) | (((PLL_P >> 1) -1) << 16) |
                    (RCC_PLLCFGR_PLLSRC_HSE) | (PLL_Q << 24));
@@ -673,7 +673,7 @@ static void SetSysClock(void)
     while((RCC->CR & RCC_CR_PLLRDY) == 0)
     {
     }
-   
+
 //#if defined (STM32F427_437xx) || defined (STM32F429_439xx) //Overdrive on STM32F427_437xx Rev A is not working
 #if  defined (STM32F429_439xx)
     /* Enable the Over-drive to extend the clock frequency to 180 Mhz */
@@ -684,14 +684,14 @@ static void SetSysClock(void)
     PWR->CR |= PWR_CR_ODSWEN;
     while((PWR->CSR & PWR_CSR_ODSWRDY) == 0)
     {
-    }      
+    }
 #endif
 #if defined (STM32F427_437xx) || defined (STM32F429_439xx)
     /* Configure Flash prefetch, Instruction cache, Data cache and wait state */
     FLASH->ACR = FLASH_ACR_PRFTEN | FLASH_ACR_ICEN |FLASH_ACR_DCEN |FLASH_ACR_LATENCY_5WS;
 #endif /* STM32F427_437x || STM32F429_439xx  */
 
-#if defined (STM32F40_41xxx)     
+#if defined (STM32F40_41xxx)
     /* Configure Flash prefetch, Instruction cache, Data cache and wait state */
     FLASH->ACR = FLASH_ACR_PRFTEN | FLASH_ACR_ICEN |FLASH_ACR_DCEN |FLASH_ACR_LATENCY_5WS;
 #endif /* STM32F40_41xxx  */
@@ -780,11 +780,11 @@ static void SetSysClock(void)
 }
 
 /**
-  * @brief  Setup the external memory controller. Called in startup_stm32f4xx.s 
+  * @brief  Setup the external memory controller. Called in startup_stm32f4xx.s
   *          before jump to __main
   * @param  None
   * @retval None
-  */ 
+  */
 #ifdef DATA_IN_ExtSRAM
 /**
   * @brief  Setup the external memory controller.
@@ -801,16 +801,16 @@ void SystemInit_ExtMemCtl(void)
  +-------------------+--------------------+------------------+--------------+
  +                       SRAM pins assignment                               +
  +-------------------+--------------------+------------------+--------------+
- | PD0  <-> FMC_D2  | PE0  <-> FMC_NBL0 | PF0  <-> FMC_A0 | PG0 <-> FMC_A10 | 
- | PD1  <-> FMC_D3  | PE1  <-> FMC_NBL1 | PF1  <-> FMC_A1 | PG1 <-> FMC_A11 | 
- | PD4  <-> FMC_NOE | PE3  <-> FMC_A19  | PF2  <-> FMC_A2 | PG2 <-> FMC_A12 | 
- | PD5  <-> FMC_NWE | PE4  <-> FMC_A20  | PF3  <-> FMC_A3 | PG3 <-> FMC_A13 | 
- | PD8  <-> FMC_D13 | PE7  <-> FMC_D4   | PF4  <-> FMC_A4 | PG4 <-> FMC_A14 | 
- | PD9  <-> FMC_D14 | PE8  <-> FMC_D5   | PF5  <-> FMC_A5 | PG5 <-> FMC_A15 | 
- | PD10 <-> FMC_D15 | PE9  <-> FMC_D6   | PF12 <-> FMC_A6 | PG9 <-> FMC_NE2 | 
+ | PD0  <-> FMC_D2  | PE0  <-> FMC_NBL0 | PF0  <-> FMC_A0 | PG0 <-> FMC_A10 |
+ | PD1  <-> FMC_D3  | PE1  <-> FMC_NBL1 | PF1  <-> FMC_A1 | PG1 <-> FMC_A11 |
+ | PD4  <-> FMC_NOE | PE3  <-> FMC_A19  | PF2  <-> FMC_A2 | PG2 <-> FMC_A12 |
+ | PD5  <-> FMC_NWE | PE4  <-> FMC_A20  | PF3  <-> FMC_A3 | PG3 <-> FMC_A13 |
+ | PD8  <-> FMC_D13 | PE7  <-> FMC_D4   | PF4  <-> FMC_A4 | PG4 <-> FMC_A14 |
+ | PD9  <-> FMC_D14 | PE8  <-> FMC_D5   | PF5  <-> FMC_A5 | PG5 <-> FMC_A15 |
+ | PD10 <-> FMC_D15 | PE9  <-> FMC_D6   | PF12 <-> FMC_A6 | PG9 <-> FMC_NE2 |
  | PD11 <-> FMC_A16 | PE10 <-> FMC_D7   | PF13 <-> FMC_A7 |-----------------+
- | PD12 <-> FMC_A17 | PE11 <-> FMC_D8   | PF14 <-> FMC_A8 | 
- | PD13 <-> FMC_A18 | PE12 <-> FMC_D9   | PF15 <-> FMC_A9 | 
+ | PD12 <-> FMC_A17 | PE11 <-> FMC_D8   | PF14 <-> FMC_A8 |
+ | PD13 <-> FMC_A18 | PE12 <-> FMC_D9   | PF15 <-> FMC_A9 |
  | PD14 <-> FMC_D0  | PE13 <-> FMC_D10  |-----------------+
  | PD15 <-> FMC_D1  | PE14 <-> FMC_D11  |
  |                  | PE15 <-> FMC_D12  |
@@ -818,65 +818,65 @@ void SystemInit_ExtMemCtl(void)
 */
    /* Enable GPIOD, GPIOE, GPIOF and GPIOG interface clock */
   RCC->AHB1ENR   |= 0x00000078;
-  
+
   /* Connect PDx pins to FMC Alternate function */
   GPIOD->AFR[0]  = 0x00cc00cc;
   GPIOD->AFR[1]  = 0xcccccccc;
-  /* Configure PDx pins in Alternate function mode */  
+  /* Configure PDx pins in Alternate function mode */
   GPIOD->MODER   = 0xaaaa0a0a;
-  /* Configure PDx pins speed to 100 MHz */  
+  /* Configure PDx pins speed to 100 MHz */
   GPIOD->OSPEEDR = 0xffff0f0f;
-  /* Configure PDx pins Output type to push-pull */  
+  /* Configure PDx pins Output type to push-pull */
   GPIOD->OTYPER  = 0x00000000;
-  /* No pull-up, pull-down for PDx pins */ 
+  /* No pull-up, pull-down for PDx pins */
   GPIOD->PUPDR   = 0x00000000;
 
   /* Connect PEx pins to FMC Alternate function */
   GPIOE->AFR[0]  = 0xcccccccc;
   GPIOE->AFR[1]  = 0xcccccccc;
-  /* Configure PEx pins in Alternate function mode */ 
+  /* Configure PEx pins in Alternate function mode */
   GPIOE->MODER   = 0xaaaaaaaa;
-  /* Configure PEx pins speed to 100 MHz */ 
+  /* Configure PEx pins speed to 100 MHz */
   GPIOE->OSPEEDR = 0xffffffff;
-  /* Configure PEx pins Output type to push-pull */  
+  /* Configure PEx pins Output type to push-pull */
   GPIOE->OTYPER  = 0x00000000;
-  /* No pull-up, pull-down for PEx pins */ 
+  /* No pull-up, pull-down for PEx pins */
   GPIOE->PUPDR   = 0x00000000;
 
   /* Connect PFx pins to FMC Alternate function */
   GPIOF->AFR[0]  = 0x00cccccc;
   GPIOF->AFR[1]  = 0xcccc0000;
-  /* Configure PFx pins in Alternate function mode */   
+  /* Configure PFx pins in Alternate function mode */
   GPIOF->MODER   = 0xaa000aaa;
-  /* Configure PFx pins speed to 100 MHz */ 
+  /* Configure PFx pins speed to 100 MHz */
   GPIOF->OSPEEDR = 0xff000fff;
-  /* Configure PFx pins Output type to push-pull */  
+  /* Configure PFx pins Output type to push-pull */
   GPIOF->OTYPER  = 0x00000000;
-  /* No pull-up, pull-down for PFx pins */ 
+  /* No pull-up, pull-down for PFx pins */
   GPIOF->PUPDR   = 0x00000000;
 
   /* Connect PGx pins to FMC Alternate function */
   GPIOG->AFR[0]  = 0x00cccccc;
   GPIOG->AFR[1]  = 0x000000c0;
-  /* Configure PGx pins in Alternate function mode */ 
+  /* Configure PGx pins in Alternate function mode */
   GPIOG->MODER   = 0x00080aaa;
-  /* Configure PGx pins speed to 100 MHz */ 
+  /* Configure PGx pins speed to 100 MHz */
   GPIOG->OSPEEDR = 0x000c0fff;
-  /* Configure PGx pins Output type to push-pull */  
+  /* Configure PGx pins Output type to push-pull */
   GPIOG->OTYPER  = 0x00000000;
-  /* No pull-up, pull-down for PGx pins */ 
+  /* No pull-up, pull-down for PGx pins */
   GPIOG->PUPDR   = 0x00000000;
-  
+
 /*-- FMC Configuration ------------------------------------------------------*/
   /* Enable the FMC/FSMC interface clock */
   RCC->AHB3ENR         |= 0x00000001;
-  
+
 #if defined (STM32F427_437xx) || defined (STM32F429_439xx)
   /* Configure and enable Bank1_SRAM2 */
   FMC_Bank1->BTCR[2]  = 0x00001011;
   FMC_Bank1->BTCR[3]  = 0x00000201;
   FMC_Bank1E->BWTR[2] = 0x0fffffff;
-#endif /* STM32F427_437xx || STM32F429_439xx */ 
+#endif /* STM32F427_437xx || STM32F429_439xx */
 
 #if defined (STM32F40_41xxx)
   /* Configure and enable Bank1_SRAM2 */
@@ -887,7 +887,7 @@ void SystemInit_ExtMemCtl(void)
 
 /*
   Bank1_SRAM2 is configured as follow:
-  In case of FSMC configuration 
+  In case of FSMC configuration
   NORSRAMTimingStructure.FSMC_AddressSetupTime = 1;
   NORSRAMTimingStructure.FSMC_AddressHoldTime = 0;
   NORSRAMTimingStructure.FSMC_DataSetupTime = 2;
@@ -901,7 +901,7 @@ void SystemInit_ExtMemCtl(void)
   FSMC_NORSRAMInitStructure.FSMC_MemoryType = FSMC_MemoryType_SRAM;
   FSMC_NORSRAMInitStructure.FSMC_MemoryDataWidth = FSMC_MemoryDataWidth_16b;
   FSMC_NORSRAMInitStructure.FSMC_BurstAccessMode = FSMC_BurstAccessMode_Disable;
-  FSMC_NORSRAMInitStructure.FSMC_AsynchronousWait = FSMC_AsynchronousWait_Disable;  
+  FSMC_NORSRAMInitStructure.FSMC_AsynchronousWait = FSMC_AsynchronousWait_Disable;
   FSMC_NORSRAMInitStructure.FSMC_WaitSignalPolarity = FSMC_WaitSignalPolarity_Low;
   FSMC_NORSRAMInitStructure.FSMC_WrapMode = FSMC_WrapMode_Disable;
   FSMC_NORSRAMInitStructure.FSMC_WaitSignalActive = FSMC_WaitSignalActive_BeforeWaitState;
@@ -912,7 +912,7 @@ void SystemInit_ExtMemCtl(void)
   FSMC_NORSRAMInitStructure.FSMC_ReadWriteTimingStruct = &NORSRAMTimingStructure;
   FSMC_NORSRAMInitStructure.FSMC_WriteTimingStruct = &NORSRAMTimingStructure;
 
-  In case of FMC configuration   
+  In case of FMC configuration
   NORSRAMTimingStructure.FMC_AddressSetupTime = 1;
   NORSRAMTimingStructure.FMC_AddressHoldTime = 0;
   NORSRAMTimingStructure.FMC_DataSetupTime = 2;
@@ -926,7 +926,7 @@ void SystemInit_ExtMemCtl(void)
   FMC_NORSRAMInitStructure.FMC_MemoryType = FMC_MemoryType_SRAM;
   FMC_NORSRAMInitStructure.FMC_MemoryDataWidth = FMC_MemoryDataWidth_16b;
   FMC_NORSRAMInitStructure.FMC_BurstAccessMode = FMC_BurstAccessMode_Disable;
-  FMC_NORSRAMInitStructure.FMC_AsynchronousWait = FMC_AsynchronousWait_Disable;  
+  FMC_NORSRAMInitStructure.FMC_AsynchronousWait = FMC_AsynchronousWait_Disable;
   FMC_NORSRAMInitStructure.FMC_WaitSignalPolarity = FMC_WaitSignalPolarity_Low;
   FMC_NORSRAMInitStructure.FMC_WrapMode = FMC_WrapMode_Disable;
   FMC_NORSRAMInitStructure.FMC_WaitSignalActive = FMC_WaitSignalActive_BeforeWaitState;
@@ -938,10 +938,10 @@ void SystemInit_ExtMemCtl(void)
   FMC_NORSRAMInitStructure.FMC_ReadWriteTimingStruct = &NORSRAMTimingStructure;
   FMC_NORSRAMInitStructure.FMC_WriteTimingStruct = &NORSRAMTimingStructure;
 */
-  
+
 }
 #endif /* DATA_IN_ExtSRAM */
-  
+
 #ifdef DATA_IN_ExtSDRAM
 /**
   * @brief  Setup the external memory controller.
@@ -956,163 +956,163 @@ void SystemInit_ExtMemCtl(void)
   register uint32_t tmpreg = 0, timeout = 0xFFFF;
   register uint32_t index;
 
-  /* Enable GPIOC, GPIOD, GPIOE, GPIOF, GPIOG, GPIOH and GPIOI interface 
+  /* Enable GPIOC, GPIOD, GPIOE, GPIOF, GPIOG, GPIOH and GPIOI interface
       clock */
   RCC->AHB1ENR |= 0x000001FC;
-  
+
   /* Connect PCx pins to FMC Alternate function */
   GPIOC->AFR[0]  = 0x0000000c;
   GPIOC->AFR[1]  = 0x00007700;
-  /* Configure PCx pins in Alternate function mode */  
+  /* Configure PCx pins in Alternate function mode */
   GPIOC->MODER   = 0x00a00002;
-  /* Configure PCx pins speed to 50 MHz */  
+  /* Configure PCx pins speed to 50 MHz */
   GPIOC->OSPEEDR = 0x00a00002;
-  /* Configure PCx pins Output type to push-pull */  
+  /* Configure PCx pins Output type to push-pull */
   GPIOC->OTYPER  = 0x00000000;
-  /* No pull-up, pull-down for PCx pins */ 
+  /* No pull-up, pull-down for PCx pins */
   GPIOC->PUPDR   = 0x00500000;
-  
+
   /* Connect PDx pins to FMC Alternate function */
   GPIOD->AFR[0]  = 0x000000CC;
   GPIOD->AFR[1]  = 0xCC000CCC;
-  /* Configure PDx pins in Alternate function mode */  
+  /* Configure PDx pins in Alternate function mode */
   GPIOD->MODER   = 0xA02A000A;
-  /* Configure PDx pins speed to 50 MHz */  
+  /* Configure PDx pins speed to 50 MHz */
   GPIOD->OSPEEDR = 0xA02A000A;
-  /* Configure PDx pins Output type to push-pull */  
+  /* Configure PDx pins Output type to push-pull */
   GPIOD->OTYPER  = 0x00000000;
-  /* No pull-up, pull-down for PDx pins */ 
+  /* No pull-up, pull-down for PDx pins */
   GPIOD->PUPDR   = 0x00000000;
 
   /* Connect PEx pins to FMC Alternate function */
   GPIOE->AFR[0]  = 0xC00000CC;
   GPIOE->AFR[1]  = 0xCCCCCCCC;
-  /* Configure PEx pins in Alternate function mode */ 
+  /* Configure PEx pins in Alternate function mode */
   GPIOE->MODER   = 0xAAAA800A;
-  /* Configure PEx pins speed to 50 MHz */ 
+  /* Configure PEx pins speed to 50 MHz */
   GPIOE->OSPEEDR = 0xAAAA800A;
-  /* Configure PEx pins Output type to push-pull */  
+  /* Configure PEx pins Output type to push-pull */
   GPIOE->OTYPER  = 0x00000000;
-  /* No pull-up, pull-down for PEx pins */ 
+  /* No pull-up, pull-down for PEx pins */
   GPIOE->PUPDR   = 0x00000000;
 
   /* Connect PFx pins to FMC Alternate function */
   GPIOF->AFR[0]  = 0xcccccccc;
   GPIOF->AFR[1]  = 0xcccccccc;
-  /* Configure PFx pins in Alternate function mode */   
+  /* Configure PFx pins in Alternate function mode */
   GPIOF->MODER   = 0xAA800AAA;
-  /* Configure PFx pins speed to 50 MHz */ 
+  /* Configure PFx pins speed to 50 MHz */
   GPIOF->OSPEEDR = 0xAA800AAA;
-  /* Configure PFx pins Output type to push-pull */  
+  /* Configure PFx pins Output type to push-pull */
   GPIOF->OTYPER  = 0x00000000;
-  /* No pull-up, pull-down for PFx pins */ 
+  /* No pull-up, pull-down for PFx pins */
   GPIOF->PUPDR   = 0x00000000;
 
   /* Connect PGx pins to FMC Alternate function */
   GPIOG->AFR[0]  = 0xcccccccc;
   GPIOG->AFR[1]  = 0xcccccccc;
-  /* Configure PGx pins in Alternate function mode */ 
+  /* Configure PGx pins in Alternate function mode */
   GPIOG->MODER   = 0xaaaaaaaa;
-  /* Configure PGx pins speed to 50 MHz */ 
+  /* Configure PGx pins speed to 50 MHz */
   GPIOG->OSPEEDR = 0xaaaaaaaa;
-  /* Configure PGx pins Output type to push-pull */  
+  /* Configure PGx pins Output type to push-pull */
   GPIOG->OTYPER  = 0x00000000;
-  /* No pull-up, pull-down for PGx pins */ 
+  /* No pull-up, pull-down for PGx pins */
   GPIOG->PUPDR   = 0x00000000;
-  
+
   /* Connect PHx pins to FMC Alternate function */
   GPIOH->AFR[0]  = 0x00C0CC00;
   GPIOH->AFR[1]  = 0xCCCCCCCC;
-  /* Configure PHx pins in Alternate function mode */ 
+  /* Configure PHx pins in Alternate function mode */
   GPIOH->MODER   = 0xAAAA08A0;
-  /* Configure PHx pins speed to 50 MHz */ 
+  /* Configure PHx pins speed to 50 MHz */
   GPIOH->OSPEEDR = 0xAAAA08A0;
-  /* Configure PHx pins Output type to push-pull */  
+  /* Configure PHx pins Output type to push-pull */
   GPIOH->OTYPER  = 0x00000000;
-  /* No pull-up, pull-down for PHx pins */ 
+  /* No pull-up, pull-down for PHx pins */
   GPIOH->PUPDR   = 0x00000000;
-  
+
   /* Connect PIx pins to FMC Alternate function */
   GPIOI->AFR[0]  = 0xCCCCCCCC;
   GPIOI->AFR[1]  = 0x00000CC0;
-  /* Configure PIx pins in Alternate function mode */ 
+  /* Configure PIx pins in Alternate function mode */
   GPIOI->MODER   = 0x0028AAAA;
-  /* Configure PIx pins speed to 50 MHz */ 
+  /* Configure PIx pins speed to 50 MHz */
   GPIOI->OSPEEDR = 0x0028AAAA;
-  /* Configure PIx pins Output type to push-pull */  
+  /* Configure PIx pins Output type to push-pull */
   GPIOI->OTYPER  = 0x00000000;
-  /* No pull-up, pull-down for PIx pins */ 
+  /* No pull-up, pull-down for PIx pins */
   GPIOI->PUPDR   = 0x00000000;
-  
+
 /*-- FMC Configuration ------------------------------------------------------*/
   /* Enable the FMC interface clock */
   RCC->AHB3ENR |= 0x00000001;
-  
+
   /* Configure and enable SDRAM bank1 */
   FMC_Bank5_6->SDCR[0] = 0x000029D0;
-  FMC_Bank5_6->SDTR[0] = 0x01115351;      
-  
+  FMC_Bank5_6->SDTR[0] = 0x01115351;
+
   /* SDRAM initialization sequence */
   /* Clock enable command */
-  FMC_Bank5_6->SDCMR = 0x00000011; 
-  tmpreg = FMC_Bank5_6->SDSR & 0x00000020; 
+  FMC_Bank5_6->SDCMR = 0x00000011;
+  tmpreg = FMC_Bank5_6->SDSR & 0x00000020;
   while((tmpreg != 0) && (timeout-- > 0))
   {
-    tmpreg = FMC_Bank5_6->SDSR & 0x00000020; 
+    tmpreg = FMC_Bank5_6->SDSR & 0x00000020;
   }
 
   /* Delay */
   for (index = 0; index<1000; index++);
-  
+
   /* PALL command */
-  FMC_Bank5_6->SDCMR = 0x00000012;           
+  FMC_Bank5_6->SDCMR = 0x00000012;
   timeout = 0xFFFF;
   while((tmpreg != 0) && (timeout-- > 0))
   {
-    tmpreg = FMC_Bank5_6->SDSR & 0x00000020; 
+    tmpreg = FMC_Bank5_6->SDSR & 0x00000020;
   }
-  
+
   /* Auto refresh command */
   FMC_Bank5_6->SDCMR = 0x00000073;
   timeout = 0xFFFF;
   while((tmpreg != 0) && (timeout-- > 0))
   {
-    tmpreg = FMC_Bank5_6->SDSR & 0x00000020; 
+    tmpreg = FMC_Bank5_6->SDSR & 0x00000020;
   }
- 
+
   /* MRD register program */
   FMC_Bank5_6->SDCMR = 0x00046014;
   timeout = 0xFFFF;
   while((tmpreg != 0) && (timeout-- > 0))
   {
-    tmpreg = FMC_Bank5_6->SDSR & 0x00000020; 
-  } 
-  
+    tmpreg = FMC_Bank5_6->SDSR & 0x00000020;
+  }
+
   /* Set refresh count */
   tmpreg = FMC_Bank5_6->SDRTR;
   FMC_Bank5_6->SDRTR = (tmpreg | (0x0000027C<<1));
-  
+
   /* Disable write protection */
-  tmpreg = FMC_Bank5_6->SDCR[0]; 
+  tmpreg = FMC_Bank5_6->SDCR[0];
   FMC_Bank5_6->SDCR[0] = (tmpreg & 0xFFFFFDFF);
 
 /*
   Bank1_SDRAM is configured as follow:
 
-  FMC_SDRAMTimingInitStructure.FMC_LoadToActiveDelay = 2;      
-  FMC_SDRAMTimingInitStructure.FMC_ExitSelfRefreshDelay = 6;  
-  FMC_SDRAMTimingInitStructure.FMC_SelfRefreshTime = 4;        
-  FMC_SDRAMTimingInitStructure.FMC_RowCycleDelay = 6;         
-  FMC_SDRAMTimingInitStructure.FMC_WriteRecoveryTime = 2;      
-  FMC_SDRAMTimingInitStructure.FMC_RPDelay = 2;                
-  FMC_SDRAMTimingInitStructure.FMC_RCDDelay = 2;               
+  FMC_SDRAMTimingInitStructure.FMC_LoadToActiveDelay = 2;
+  FMC_SDRAMTimingInitStructure.FMC_ExitSelfRefreshDelay = 6;
+  FMC_SDRAMTimingInitStructure.FMC_SelfRefreshTime = 4;
+  FMC_SDRAMTimingInitStructure.FMC_RowCycleDelay = 6;
+  FMC_SDRAMTimingInitStructure.FMC_WriteRecoveryTime = 2;
+  FMC_SDRAMTimingInitStructure.FMC_RPDelay = 2;
+  FMC_SDRAMTimingInitStructure.FMC_RCDDelay = 2;
 
   FMC_SDRAMInitStructure.FMC_Bank = SDRAM_BANK;
   FMC_SDRAMInitStructure.FMC_ColumnBitsNumber = FMC_ColumnBits_Number_8b;
   FMC_SDRAMInitStructure.FMC_RowBitsNumber = FMC_RowBits_Number_11b;
   FMC_SDRAMInitStructure.FMC_SDMemoryDataWidth = FMC_SDMemory_Width_16b;
   FMC_SDRAMInitStructure.FMC_InternalBankNumber = FMC_InternalBank_Number_4;
-  FMC_SDRAMInitStructure.FMC_CASLatency = FMC_CAS_Latency_3; 
+  FMC_SDRAMInitStructure.FMC_CASLatency = FMC_CAS_Latency_3;
   FMC_SDRAMInitStructure.FMC_WriteProtection = FMC_Write_Protection_Disable;
   FMC_SDRAMInitStructure.FMC_SDClockPeriod = FMC_SDClock_Period_2;
   FMC_SDRAMInitStructure.FMC_ReadBurst = FMC_Read_Burst_disable;
@@ -1131,8 +1131,8 @@ void SystemInit_ExtMemCtl(void)
 /**
   * @}
   */
-  
+
 /**
   * @}
-  */    
+  */
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/


### PR DESCRIPTION
Previously, we had to define the `BOOTIMAGE_PAGE` which sets the `VECT_TAB_OFFSET` which then sets the vector table offset register (VTOR) in `SystemInit()`. This was inconvenient because it required us to build two versions of Rodos with different offsets (for use with or without a bootloader). No longer setting the vector table offset register in `SystemInit()` (if the offset is 0) removes this requirement, and we can use the normal `rodos::rodos` target for a standalone firmware and one for use with a bootloader because the latter can set the VTOR itself.